### PR TITLE
Integrating recommonmark with Read the Docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,10 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
+import recommonmark
+from recommonmark.transform import AutoStructify
+
+source_suffix = ['.rst', '.md']
 
 
 # -- Project information -----------------------------------------------------
@@ -31,10 +35,30 @@ release = '0.0.1'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'recommonmark',
 ]
+
+    #  'sphinx.ext.autodoc',
+    #  'sphinx.ext.napoleon',
+    #  'sphinx.ext.mathjax',
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']
+
+# The encoding of source files.
+#source_encoding = 'utf-8-sig'
+
+# The master toctree document.
+master_doc = 'index'
+
+# The version info for the project you're documenting, acts as replacement for
+# |version| and |release|, also used in various other places throughout the
+# built documents.
+#
+# The short X.Y version.
+version = recommonmark.__version__
+# The full version, including alpha/beta/rc tagss
+release = recommonmark.__version__
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -53,3 +77,17 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+# app setup hook
+def setup(app):
+    app.add_config_value('recommonmark_config', {
+        #'url_resolver': lambda url: github_doc_root + url,
+        'auto_toc_tree_section': 'Contents',
+        'enable_math': False,
+        'enable_inline_math': False,
+        'enable_eval_rst': True,
+        'enable_auto_doc_ref': True,
+    }, True)
+    app.add_transform(AutoStructify)
+    
+    

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Veristand Custom Device Handbook's documentation!
+# Welcome to Veristand Custom Device Handbook's documentation!
 ============================================================
 
 .. toctree::
@@ -12,9 +12,11 @@ Welcome to Veristand Custom Device Handbook's documentation!
 
 
 
-Indices and tables
+## Indices and tables
 ==================
 
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
+
+


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-handbook/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Integrate recommonmark with Read the Docs
- Add the proper details to conf.py

### Why should this Pull Request be merged?

- To have the documentation pages in markdown format so that everyone would easily edit and submit changes.

### What testing has been done?

N/A