### PR TITLE
FIx the structure of the automatically generated toctree for Index page

### DIFF
--- a/docs/When_Do_You_Need_A_Custom_Device.md
+++ b/docs/When_Do_You_Need_A_Custom_Device.md
@@ -1,4 +1,4 @@
-#### When do you Need a Custom Device?
+### When do you Need a Custom Device?
 
 The built-in components of a VeriStand Project are listed in **[VeriStand Help](https://www.ni.com/documentation/en/veristand/latest/manual/manual-overview/)** » **[VeriStand Environment](https://www.ni.com/documentation/en/veristand/latest/manual/environment/)** » **System Explorer** section in the table. If the built-in components do not fulfill a specification, it can most likely be fulfilled by one of the customization methods shown in **[Using NI VeriStand with Other Software Environments to Create Real-Time Test Applications](https://www.ni.com/en-us/innovations/white-papers/09/using-ni-veristand-with-other-software-environments-to-create-re.html)**.
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-handbook/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Fixes the Index page automatically toc tree.

### Why should this Pull Request be merged?

- To have the Index page contain only page titles.

### What testing has been done?

- Build Passed: https://readthedocs.org/projects/niveristand-custom-device-handbook/builds/14865700/
- Index Page: https://niveristand-custom-device-handbook--22.org.readthedocs.build/en/22/