### PR TITLE
Fix Project Picture rendering in the PDF

### DIFF
--- a/docs/What_Is_A_Custom_Device.md
+++ b/docs/What_Is_A_Custom_Device.md
@@ -97,6 +97,7 @@ For each of the five types of custom devices, in the LabVIEW source project, you
 * a <span style="color:green">*&lt;Custom Device Name&gt; System Explorer.lvlib*</span> VI library.
 
 The following image displays a new custom device template project. <br />
+
 ![](images/Picture5.jpg) <br />
 
 The Custom Device API library and Custom Device Utility Library contain most of the type definitions, template VIs and LabVIEW API needed to interact with VeriStand data and timing resources. They allow the VI to behave as a native task in the VeriStand Engine.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-handbook/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Fixes the Template Project Picture rendering in the PDF export.

### Why should this Pull Request be merged?

- In order for the PDF export to render correctly the image.

### What testing has been done?

- Build Passed: https://readthedocs.org/projects/niveristand-custom-device-handbook/builds/14873822/
- Rendered Page: https://niveristand-custom-device-handbook--23.org.readthedocs.build/en/23/What_Is_A_Custom_Device.html#custom-device-framework