### PR TITLE
Scripting APIs list fix for the pdf version

### DIFF
--- a/docs/Scripting_API.md
+++ b/docs/Scripting_API.md
@@ -16,11 +16,11 @@ The functions for this Scripting API are grouped into: **Custom Device**, **Bitf
 
 ## Scripting APIs for NI supported Custom Devices
 
-The following list contains NI supported Custom Devices that have a Scripting API:
-•	[Instrument Addon Scripting API](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/main/Source/Quick%20Start%20Documentation/FPGA%20Addon%20Quick%20Start%20Guide.md#scripting-api)
-•	[FPGA Addon Scripting API](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/main/Source/Quick%20Start%20Documentation/FPGA%20Addon%20Quick%20Start%20Guide.md#scripting-api)
-•	[Routing and Faulting Scripting API](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/main/Source/Quick%20Start%20Documentation/FPGA%20Addon%20Quick%20Start%20Guide.md#scripting-api)
-•	[Engine Simulation Toolkit Scripting API](https://github.com/ni/niveristand-engine-simulation-toolkit-custom-device/tree/main/Source/Scripting%20API)
-•	[Communications Bus Template Scripting API](https://github.com/ni/niveristand-communications-bus-template/tree/main/Source/Custom%20Device%20Support/Scripting)
-•	[Ballard ARINC 429 Scripting API](https://github.com/ni/niveristand-ballard-arinc429-custom-device/blob/main/Docs/User%20Guide/User%20Guide.md#scripting-the-custom-device-configuration)
-•	[Ballard MIL-STD-1553 Scripting API](https://github.com/ni/niveristand-ballard-milStd1553-custom-device/tree/main/Source/Scripting%20Examples)
+The following list contains NI supported Custom Devices that have a Scripting API:<br />
+•	[Instrument Addon Scripting API](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/main/Source/Quick%20Start%20Documentation/FPGA%20Addon%20Quick%20Start%20Guide.md#scripting-api)<br />
+•	[FPGA Addon Scripting API](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/main/Source/Quick%20Start%20Documentation/FPGA%20Addon%20Quick%20Start%20Guide.md#scripting-api)<br />
+•	[Routing and Faulting Scripting API](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/main/Source/Quick%20Start%20Documentation/FPGA%20Addon%20Quick%20Start%20Guide.md#scripting-api)<br />
+•	[Engine Simulation Toolkit Scripting API](https://github.com/ni/niveristand-engine-simulation-toolkit-custom-device/tree/main/Source/Scripting%20API)<br />
+•	[Communications Bus Template Scripting API](https://github.com/ni/niveristand-communications-bus-template/tree/main/Source/Custom%20Device%20Support/Scripting)<br />
+•	[Ballard ARINC 429 Scripting API](https://github.com/ni/niveristand-ballard-arinc429-custom-device/blob/main/Docs/User%20Guide/User%20Guide.md#scripting-the-custom-device-configuration)<br />
+•	[Ballard MIL-STD-1553 Scripting API](https://github.com/ni/niveristand-ballard-milStd1553-custom-device/tree/main/Source/Scripting%20Examples)<br />


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-handbook/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes some display issues in the Scripting APIs list

### Why should this Pull Request be merged?

To fix the display issue

### What testing has been done?

Read The Docs build passed
https://niveristand-custom-device-handbook--25.org.readthedocs.build/en/25/Scripting_API.html