### PR TITLE
Attempt to fix the Custom Devices Scripting APIs list in the PDF

### DIFF
--- a/docs/Scripting_API.md
+++ b/docs/Scripting_API.md
@@ -20,3 +20,5 @@ The following custom devices also have a scripting API.
 * [Communications Bus Template Scripting API](https://github.com/ni/niveristand-communications-bus-template/tree/main/Source/Custom%20Device%20Support/Scripting)
 * [Ballard ARINC 429 Scripting API](https://github.com/ni/niveristand-ballard-arinc429-custom-device/blob/main/Docs/User%20Guide/User%20Guide.md#scripting-the-custom-device-configuration)
 * [Ballard MIL-STD-1553 Scripting API](https://github.com/ni/niveristand-ballard-milStd1553-custom-device/tree/main/Source/Scripting%20Examples)
+
+<br />


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-handbook/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Attempts to fix the Scripting API list of NI Supported Custom Devices that broke after Tech Writer Review.

### Why should this Pull Request be merged?

- To show the list also in the PDF manual.

### What testing has been done?

- Build result: https://readthedocs.org/projects/niveristand-custom-device-handbook/builds/15051227/
- Rendered page: https://niveristand-custom-device-handbook--29.org.readthedocs.build/en/29/Scripting_API.html