### PR TITLE
Fix the Instrument Addon and Routing and Faulting Scripting APIs links.

### DIFF
--- a/docs/Scripting_API.md
+++ b/docs/Scripting_API.md
@@ -14,11 +14,11 @@ One example is the [FPGA Addon Scripting API](https://github.com/ni/niveristand-
 
 The following custom devices also have a scripting API.
 
-* [Instrument Addon Scripting API](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/main/Source/Quick%20Start%20Documentation/FPGA%20Addon%20Quick%20Start%20Guide.md#scripting-api)
-* [Routing and Faulting Scripting API](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/main/Source/Quick%20Start%20Documentation/FPGA%20Addon%20Quick%20Start%20Guide.md#scripting-api)
-* [Engine Simulation Toolkit Scripting API](https://github.com/ni/niveristand-engine-simulation-toolkit-custom-device/tree/main/Source/Scripting%20API)
-* [Communications Bus Template Scripting API](https://github.com/ni/niveristand-communications-bus-template/tree/main/Source/Custom%20Device%20Support/Scripting)
-* [Ballard ARINC 429 Scripting API](https://github.com/ni/niveristand-ballard-arinc429-custom-device/blob/main/Docs/User%20Guide/User%20Guide.md#scripting-the-custom-device-configuration)
-* [Ballard MIL-STD-1553 Scripting API](https://github.com/ni/niveristand-ballard-milStd1553-custom-device/tree/main/Source/Scripting%20Examples)
+* [Instrument Addon Scripting API](https://github.com/ni/niveristand-instrument-addon-custom-device/blob/main/Source/Quick%20Start%20Documentation/Instrument%20Addon%20Quick%20Start%20Guide.md#scripting-api)<br />
+* [Routing and Faulting Scripting API](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/Docs/User%20Guide.md#scripting-api)<br />
+* [Engine Simulation Toolkit Scripting API](https://github.com/ni/niveristand-engine-simulation-toolkit-custom-device/tree/main/Source/Scripting%20API)<br />
+* [Communications Bus Template Scripting API](https://github.com/ni/niveristand-communications-bus-template/tree/main/Source/Custom%20Device%20Support/Scripting)<br />
+* [Ballard ARINC 429 Scripting API](https://github.com/ni/niveristand-ballard-arinc429-custom-device/blob/main/Docs/User%20Guide/User%20Guide.md#scripting-the-custom-device-configuration)<br />
+* [Ballard MIL-STD-1553 Scripting API](https://github.com/ni/niveristand-ballard-milStd1553-custom-device/tree/main/Source/Scripting%20Examples)<br />
 
 <br />


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-handbook/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Update the Scripting API page with the correct links for:
    -  Instrument Addon Scripting API
    - Routing and Faulting Scripting API
- Fix the missing list inside the PDF document.

### Why should this Pull Request be merged?

- In order for the links to be correct.
- To show this list inside the PDF.

### What testing has been done?

- RTD build passed: https://readthedocs.org/projects/niveristand-custom-device-handbook/builds/15191017/
- RTD PR page: https://niveristand-custom-device-handbook--31.org.readthedocs.build/en/31/Scripting_API.html