### PR TITLE
Release preparation - updating copyright, release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# niveristand-custom-device-handbook
+# VeriStand Custom Device Handbook
+
+The **[VeriStand Custom Device Handbook](https://niveristand-custom-device-handbook.readthedocs.io/en/latest/index.html)** contains documentation for VeriStand Custom Devices development.
+
+## Git History & Rebasing Policy
+
+Branch rebasing and other history modifications will be listed here, with several notable exceptions:
+- Branches prefixed with `dev/` may be rebased, overwritten, or deleted at any time.
+- Pull requests may be squashed on merge.
+
+## License
+The VeriStand Custom Device Handbook is licensed under an MIT-style license (see LICENSE). Other incorporated projects may be licensed under different licenses. All licenses allow for non-commercial and commercial use.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,12 +21,12 @@ source_suffix = ['.rst', '.md']
 
 # -- Project information -----------------------------------------------------
 
-project = 'Veristand Custom Device Handbook'
-copyright = '2021, NI'
+project = 'VeriStand Custom Device Handbook'
+copyright = '2022, NI'
 author = 'NI'
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.1'
+release = '1.0.0'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-handbook/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Changes the `project` name visible in the web page from `Veristand Custom Device Handbook` to `VeriStand Custom Device Hanbook` (typo in Veri`S`tand).
- Updates the `copyright` year to 2022, as it will be released at the end of this Cycle.
- Changes the `release` to `1.0.0` to match the expected release version we want.

### Why should this Pull Request be merged?

- In order to prepare the Custom Device Handbook for release.

### What testing has been done?

- Build result [passed](https://readthedocs.org/projects/niveristand-custom-device-handbook/builds/15483553/).
- Page [rendering](https://niveristand-custom-device-handbook--36.org.readthedocs.build/en/36/).
![image](https://user-images.githubusercontent.com/62251693/145234030-abaa2e96-4324-4fee-90f8-e8c9b4d59fc5.png)
